### PR TITLE
Update syntax to reflect incompatible changes from tmux 2.0 to 2.1

### DIFF
--- a/syntax/tmux.vim
+++ b/syntax/tmux.vim
@@ -191,9 +191,6 @@ syn keyword tmuxOptsSet
 	\ message-command-style
 	\ message-limit
 	\ message-style
-	\ mouse-resize-pane
-	\ mouse-select-pane
-	\ mouse-select-window
 	\ mouse-utf8
 	\ pane-active-border-style
 	\ pane-border-style
@@ -241,11 +238,11 @@ syn keyword tmuxOptsSetw
 	\ main-pane-height
 	\ main-pane-width
 	\ mode-keys
-	\ mode-mouse
 	\ mode-style
 	\ monitor-activity
 	\ monitor-content
 	\ monitor-silence
+	\ mouse
 	\ other-pane-height
 	\ other-pane-width
 	\ pane-base-index


### PR DESCRIPTION
As for the [changelog](https://raw.githubusercontent.com/tmux/tmux/master/CHANGES):

````
* Mouse-mode has been rewritten.  There's now no longer options for:
	- mouse-resize-pane
	- mouse-select-pane
	- mouse-select-window
	- mode-mouse

  Instead there is just one option:  'mouse' which turns on mouse support
  entirely.
````