### PR TITLE
Syntax improvement

### DIFF
--- a/syntax/tmux.vim
+++ b/syntax/tmux.vim
@@ -26,7 +26,7 @@ endif
 setlocal iskeyword+=-
 syntax case match
 
-syn keyword tmuxAction	any current none
+syn keyword tmuxAction	any current default none
 syn keyword tmuxBoolean	off on
 
 syn keyword tmuxCmds

--- a/syntax/tmux.vim
+++ b/syntax/tmux.vim
@@ -259,24 +259,36 @@ syn keyword tmuxOptsSetw
 	\ force-width
 	\ main-pane-height
 	\ main-pane-width
+	\ message-attr
+	\ message-bg
+	\ message-fg
 	\ mode-keys
 	\ mode-style
 	\ monitor-activity
 	\ monitor-silence
 	\ other-pane-height
 	\ other-pane-width
+	\ pane-active-border-bg
+	\ pane-active-border-fg
 	\ pane-active-border-style
 	\ pane-base-index
+	\ pane-border-fg
 	\ pane-border-style
 	\ remain-on-exit
 	\ synchronize-panes
 	\ window-active-style
+	\ window-status-activity-attr
+	\ window-status-activity-bg
+	\ window-status-activity-fg
 	\ window-status-activity-style
 	\ window-status-bell-style
+	\ window-status-bg
+	\ window-status-current-attr
 	\ window-status-current-bg
 	\ window-status-current-fg
 	\ window-status-current-format
 	\ window-status-current-style
+	\ window-status-fg
 	\ window-status-format
 	\ window-status-last-style
 	\ window-status-separator

--- a/syntax/tmux.vim
+++ b/syntax/tmux.vim
@@ -300,7 +300,7 @@ syn keyword tmuxOptsSetw
 syn keyword tmuxTodo FIXME NOTE TODO XXX contained
 
 syn match tmuxKey		/\(C-\|M-\|\^\)\+\S\+/	display
-syn match tmuxNumber 		/\d\+/			display
+syn match tmuxNumber 		/\<\d\+\>/			display
 syn match tmuxOptions		/\s-\a\+/		display
 syn match tmuxVariable		/\w\+=/			display
 syn match tmuxVariableExpansion	/\${\=\w\+}\=/		display


### PR DESCRIPTION
Add the following keywords

* message-attr
* message-bg
* message-fg
* pane-active-border-bg
* pane-active-border-fg
* pane-border-fg
* window-status-activity-attr
* window-status-activity-bg
* window-status-activity-fg
* window-status-bg
* window-status-current-attr
* window-status-fg

Fix the `Number` regex to not match numbers inside an identifier such as `colour42`.

Add `default` to the `tmuxAction` list.

I kept the changes in separeted in case I need to rollback something, tell me if you'd prefer all changes in a single commit...
